### PR TITLE
Fix negative padding class

### DIFF
--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -43,7 +43,7 @@ const Homepage = () => {
           <div className='pt-24'>
           <LoadingScreen />
             </div>
-          <div className='text-white -pt-48 flex flex-col text-7xl justify-center items-center h-screen font-serif '> 
+          <div className='text-white -mt-48 flex flex-col text-7xl justify-center items-center h-screen font-serif '>
             <div>
             Mukesh
             </div>


### PR DESCRIPTION
## Summary
- use `-mt-48` instead of invalid `-pt-48` in Homepage

## Testing
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime'...)*
- `npm run lint` *(fails: Cannot find package '@eslint/js'...)*

------
https://chatgpt.com/codex/tasks/task_e_684cf6abcb648327a51e333ac4114118